### PR TITLE
Unassigned applications

### DIFF
--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
@@ -9,10 +9,7 @@ import com.emeraldElves.alcohollabelproject.Log;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 /**
  * Created by elijaheldredge on 3/31/17.
@@ -186,7 +183,7 @@ public class AlcoholDatabase {
     public boolean submitApplication(SubmittedApplication application, String username) {
 
         if (AppState.getInstance().ttbAgents == null) {
-            AppState.getInstance().ttbAgents = new ApplicationAssigner(new LazyAssigner(), new ArrayList<>());
+            AppState.getInstance().ttbAgents = new ApplicationAssigner(new LazyAssigner(), Arrays.asList("PENDING"));
         }
         //making application type
         ApplicationType appType = application.getApplication().getApplicationType();

--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
@@ -186,7 +186,7 @@ public class AlcoholDatabase {
     public boolean submitApplication(SubmittedApplication application, String username) {
 
         if (AppState.getInstance().ttbAgents == null) {
-            AppState.getInstance().ttbAgents = new MultiApplicationAssigner(usersDatabase.getAllAgents(), 10, 0);
+            AppState.getInstance().ttbAgents = new ApplicationAssigner(new LazyAssigner(), null);
         }
         //making application type
         ApplicationType appType = application.getApplication().getApplicationType();
@@ -607,6 +607,11 @@ public class AlcoholDatabase {
         }
         return true;
     }
+
+    public List<SubmittedApplication> getUnassignedApplications(){
+        return getAssignedApplications("PENDING");
+    }
+
     public boolean saveUpdateHistory(SubmittedApplication application, String username) {
         //making application type
         ApplicationType appType = application.getApplication().getApplicationType();

--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/AlcoholDatabase.java
@@ -186,7 +186,7 @@ public class AlcoholDatabase {
     public boolean submitApplication(SubmittedApplication application, String username) {
 
         if (AppState.getInstance().ttbAgents == null) {
-            AppState.getInstance().ttbAgents = new ApplicationAssigner(new LazyAssigner(), null);
+            AppState.getInstance().ttbAgents = new ApplicationAssigner(new LazyAssigner(), new ArrayList<>());
         }
         //making application type
         ApplicationType appType = application.getApplication().getApplicationType();

--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/ApplicationAssigner.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/ApplicationAssigner.java
@@ -8,7 +8,7 @@ import java.util.ListIterator;
 /**
  * Created by Joe on 4/9/2017.
  */
-public abstract class ApplicationAssigner {
+public class ApplicationAssigner {
     protected IAssigner assigner;
     private List<String> agentUserNames;
     private String lastAssignedAgent;
@@ -30,7 +30,7 @@ public abstract class ApplicationAssigner {
      * assignAgent() uses round robin to assign an agent
      * @return new agent's username
      */
-    String assignAgent() {
+    public String assignAgent() {
         this.lastAssignedAgent = assigner.assignAgent(agentUserNames, lastAssignedAgent);
         return lastAssignedAgent;
     }

--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/LazyAssigner.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/LazyAssigner.java
@@ -1,0 +1,13 @@
+package com.emeraldElves.alcohollabelproject.Data;
+
+import java.util.List;
+
+/**
+ * Created by Kyle on 4/30/2017.
+ */
+public class LazyAssigner implements IAssigner {
+    @Override
+    public String assignAgent(List<String> agentNames, String nextAgentToAssign) {
+        return "PENDING";
+    }
+}

--- a/src/main/java/com/emeraldElves/alcohollabelproject/Data/Storage.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/Data/Storage.java
@@ -437,4 +437,8 @@ public class Storage {
     public void modifyName(String email, String name) {
 
     }
+
+    public List<SubmittedApplication> getUnassignedApplications(){
+        return alcoholDB.getUnassignedApplications();
+    }
 }

--- a/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/SuperagentViewAllApplicationsController.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/SuperagentViewAllApplicationsController.java
@@ -49,6 +49,7 @@ public class SuperagentViewAllApplicationsController implements IController{
         this.main = main;
         //list of all ttb agent usernames
         List<String> names = Storage.getInstance().getAllTTBUsernames();
+        names.add("PENDING");
 
 
 

--- a/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
@@ -1,14 +1,12 @@
 package com.emeraldElves.alcohollabelproject.UserInterface;
 
 import com.emeraldElves.alcohollabelproject.Authenticator;
-import com.emeraldElves.alcohollabelproject.Data.DateHelper;
-import com.emeraldElves.alcohollabelproject.Data.Storage;
-import com.emeraldElves.alcohollabelproject.Data.SubmittedApplication;
-import com.emeraldElves.alcohollabelproject.Data.TTBAgentInterface;
+import com.emeraldElves.alcohollabelproject.Data.*;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.control.CheckBox;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableRow;
 import javafx.scene.control.TableView;
@@ -16,6 +14,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by Kylec on 4/18/2017.
@@ -37,6 +36,16 @@ public class TTBWorkflowController implements IController {
 
     private ObservableList<SubmittedApplication> data = FXCollections.observableArrayList();
     private TTBAgentInterface agentInterface;
+
+    @FXML
+    private CheckBox beer;
+
+    @FXML
+    private CheckBox wine;
+
+    @FXML
+    private CheckBox spirits;
+
 
     private Main main;
 
@@ -75,6 +84,14 @@ public class TTBWorkflowController implements IController {
 
     public void fetchApplications(){
         List<SubmittedApplication> unassigned = Storage.getInstance().getUnassignedApplications();
+
+        unassigned = unassigned.stream().filter((a) -> {
+            AlcoholType type = a.getApplication().getAlcohol().getAlcoholType();
+            return type.equals(AlcoholType.BEER) && beer.isSelected() ||
+                    type.equals(AlcoholType.WINE) && wine.isSelected() ||
+                    type.equals(AlcoholType.DISTILLEDSPIRITS) && spirits.isSelected();
+        }).collect(Collectors.toList());
+
         int numAssigned = agentInterface.getAssignedApplications().size();
         for (int i = numAssigned; i < 10 && unassigned.size() > 0; i++) {
             agentInterface.addApplication(unassigned.get(0));

--- a/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
@@ -80,6 +80,9 @@ public class TTBWorkflowController implements IController {
             agentInterface.addApplication(unassigned.get(0));
             unassigned.remove(0);
         }
+        List<SubmittedApplication> resultsList = agentInterface.getAssignedApplications();
+        data.clear();
+        data.addAll(resultsList);
     }
 
 }

--- a/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
+++ b/src/main/java/com/emeraldElves/alcohollabelproject/UserInterface/TTBWorkflowController.java
@@ -2,6 +2,7 @@ package com.emeraldElves.alcohollabelproject.UserInterface;
 
 import com.emeraldElves.alcohollabelproject.Authenticator;
 import com.emeraldElves.alcohollabelproject.Data.DateHelper;
+import com.emeraldElves.alcohollabelproject.Data.Storage;
 import com.emeraldElves.alcohollabelproject.Data.SubmittedApplication;
 import com.emeraldElves.alcohollabelproject.Data.TTBAgentInterface;
 import javafx.beans.property.ReadOnlyObjectWrapper;
@@ -70,6 +71,15 @@ public class TTBWorkflowController implements IController {
         //Find & add matching applications
         List<SubmittedApplication> resultsList = agentInterface.getAssignedApplications();
         data.addAll(resultsList);
+    }
+
+    public void fetchApplications(){
+        List<SubmittedApplication> unassigned = Storage.getInstance().getUnassignedApplications();
+        int numAssigned = agentInterface.getAssignedApplications().size();
+        for (int i = numAssigned; i < 10 && unassigned.size() > 0; i++) {
+            agentInterface.addApplication(unassigned.get(0));
+            unassigned.remove(0);
+        }
     }
 
 }

--- a/src/main/resources/fxml/TTBWorkflowPage.fxml
+++ b/src/main/resources/fxml/TTBWorkflowPage.fxml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.scene.control.Button?>
+<?import javafx.scene.control.CheckBox?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.AnchorPane?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
@@ -27,8 +29,15 @@
             <TableColumn fx:id="appIDCol" maxWidth="1.7976931348623157E308" minWidth="190.0" prefWidth="190.0" resizable="false" text="Application ID" />
          </columns>
       </TableView>
-      <Label alignment="CENTER" prefHeight="25.0" prefWidth="1110.0" styleClass="card-title" text="Assigned Applications" GridPane.rowIndex="1" />
       <fx:include source="toolbar.fxml" />
-      <Button mnemonicParsing="false" onMouseClicked="#fetchApplications" prefHeight="38.0" prefWidth="184.0" styleClass="button-raised" text="FETCH APPLICATIONS" GridPane.rowIndex="1" />
+      <AnchorPane prefHeight="200.0" prefWidth="200.0" GridPane.rowIndex="1">
+         <children>
+            <Button layoutX="14.0" layoutY="22.0" mnemonicParsing="false" onMouseClicked="#fetchApplications" prefHeight="38.0" prefWidth="184.0" styleClass="button-raised" text="FETCH APPLICATIONS" />
+            <Label layoutX="237.0" layoutY="19.0" style="-fx-font-size: 32;" text="Assigned Applications" />
+            <CheckBox fx:id="beer" layoutX="589.0" layoutY="21.0" mnemonicParsing="false" selected="true" text="Pull beer" />
+            <CheckBox fx:id="wine" layoutX="718.0" layoutY="21.0" mnemonicParsing="false" selected="true" text="Pull wine" />
+            <CheckBox fx:id="spirits" layoutX="840.0" layoutY="21.0" mnemonicParsing="false" selected="true" text="Pull distilled spirits" />
+         </children>
+      </AnchorPane>
    </children>
 </GridPane>

--- a/src/main/resources/fxml/TTBWorkflowPage.fxml
+++ b/src/main/resources/fxml/TTBWorkflowPage.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.control.TableColumn?>
 <?import javafx.scene.control.TableView?>
@@ -7,7 +8,7 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.RowConstraints?>
 
-<GridPane maxHeight="768.0" maxWidth="1024.0" minHeight="768.0" minWidth="1024.0" prefHeight="768.0" prefWidth="1024.0" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.emeraldElves.alcohollabelproject.UserInterface.TTBWorkflowController">
+<GridPane maxHeight="768.0" maxWidth="1024.0" minHeight="768.0" minWidth="1024.0" prefHeight="768.0" prefWidth="1024.0" xmlns="http://javafx.com/javafx/8.0.102" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.emeraldElves.alcohollabelproject.UserInterface.TTBWorkflowController">
   <columnConstraints>
     <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
   </columnConstraints>
@@ -28,5 +29,6 @@
       </TableView>
       <Label alignment="CENTER" prefHeight="25.0" prefWidth="1110.0" styleClass="card-title" text="Assigned Applications" GridPane.rowIndex="1" />
       <fx:include source="toolbar.fxml" />
+      <Button mnemonicParsing="false" onMouseClicked="#fetchApplications" prefHeight="38.0" prefWidth="184.0" styleClass="button-raised" text="FETCH APPLICATIONS" GridPane.rowIndex="1" />
    </children>
 </GridPane>


### PR DESCRIPTION
Allow agents to fetch applications, and filter which ones they fetch. Limited to 10 apps at a time, fixes bunch of round robin bugs because it doesn't use round robin. 